### PR TITLE
Added license and repository fields to avoid warnings in npm install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,5 +2,12 @@
     "dependencies": {
         "aws-sdk": ">= 2.0.9",
         "node-uuid": ">= 1.4.1"
+    },
+
+    "license": "(Apache-2.0)",
+
+    "repository" : {
+        "type" : "git",
+        "url" : "https://github.com/awslabs/aws-nodejs-sample.git"
     }
 }


### PR DESCRIPTION
Adds license and repository fields to **package.json**. This avoids warnings in npm install:

aws-nodejs-sample$ npm install
aws-nodejs-sample
├─┬ aws-sdk@2.4.0 
│ ├── jmespath@0.15.0 
│ ├── sax@1.1.5 
│ ├── xml2js@0.4.15 
│ └─┬ xmlbuilder@2.6.2 
│   └── lodash@3.5.0 
└── node-uuid@1.4.7 

aws-nodejs-sample$
