### PR TITLE
Use uuid package and added config so sample can work with Mac OSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
     "dependencies": {
+        "aws-config": "^1.1.4",
         "aws-sdk": ">= 2.0.9",
-        "node-uuid": ">= 1.4.1"
+        "node-uuid": ">= 1.4.1",
+        "save": "^2.3.2"
     }
 }

--- a/sample.js
+++ b/sample.js
@@ -18,12 +18,20 @@
 var AWS = require('aws-sdk');
 var uuid = require('node-uuid');
 
+// Insert credential info if using Mac OSX
+AWS.config.update({
+  accessKeyId: 'accessKeyId',  
+  secretAccessKey: 'secretAccessKey',  
+  timeout: 15000                      
+}); 
+
 // Create an S3 client
 var s3 = new AWS.S3();
 
 // Create a bucket and upload something into it
 var bucketName = 'node-sdk-sample-' + uuid.v4();
 var keyName = 'hello_world.txt';
+
 
 s3.createBucket({Bucket: bucketName}, function() {
   var params = {Bucket: bucketName, Key: keyName, Body: 'Hello World!'};


### PR DESCRIPTION
*Description of changes:*
The original node-uuid package is deprecated, so we need to use uuid package instead. See this link for further info: 
https://www.npmjs.com/package/node-uuid

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
