### PR TITLE
replaced node-uuid with uuid

### DIFF
--- a/sample.js
+++ b/sample.js
@@ -16,7 +16,7 @@
 
 // Load the SDK and UUID
 var AWS = require('aws-sdk');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 // Create an S3 client
 var s3 = new AWS.S3();


### PR DESCRIPTION
As node-uuid module is deprecated, so replacing the same with uuid

Issue #18 

As node-uuid module is deprecated, so replacing the same with uuid to be compliant. the same can be verified from - https://www.npmjs.com/package/node-uuid



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
